### PR TITLE
chore(deps): update markdownlint to v0.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 	"dependencies": {
 		"globby": "^14.1.0",
 		"js-yaml": "^4.1.0",
-		"markdownlint": "^0.38.0",
+		"markdownlint": "^0.39.0",
 		"vscode-languageserver": "^9.0.1",
 		"vscode-languageserver-textdocument": "^1.0.12"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       markdownlint:
-        specifier: ^0.38.0
-        version: 0.38.0
+        specifier: ^0.39.0
+        version: 0.39.0
       vscode-languageserver:
         specifier: ^9.0.1
         version: 9.0.1
@@ -205,8 +205,8 @@ packages:
     resolution: {integrity: sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg==}
     hasBin: true
 
-  markdownlint@0.38.0:
-    resolution: {integrity: sha512-xaSxkaU7wY/0852zGApM8LdlIfGCW8ETZ0Rr62IQtAnUMlMuifsg09vWJcNYeL4f0anvr8Vo4ZQar8jGpV0btQ==}
+  markdownlint@0.39.0:
+    resolution: {integrity: sha512-Xt/oY7bAiHwukL1iru2np5LIkhwD19Y7frlsiDILK62v3jucXCD6JXlZlwMG12HZOR+roHIVuJZrfCkOhp6k3g==}
     engines: {node: '>=20'}
 
   merge2@1.4.1:
@@ -492,7 +492,7 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  markdownlint@0.38.0:
+  markdownlint@0.39.0:
     dependencies:
       micromark: 4.0.2
       micromark-core-commonmark: 2.0.3


### PR DESCRIPTION
Bump markdownlint version to latest: https://github.com/DavidAnson/markdownlint/tags

Version adds support for MD060 - table-column-style (possibly others).