### PR TITLE
feat(server): support .markdownlintignore files

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -2,6 +2,10 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { load } from "js-yaml";
 import { readConfig as readMarkdownlintConfig } from "markdownlint/promise";
+import {
+	loadMarkdownlintIgnoreEntries,
+	MARKDOWNLINT_IGNORE_FILENAME,
+} from "./markdownlint-ignore.mjs";
 import mergeOptions from "./merge-options.mjs";
 
 // The order of these filenames is important and reflects the precedence
@@ -36,6 +40,8 @@ export const ALL_CONFIG_FILENAMES_EXCEPT_PACKAGE_JSON = [
 	...MARKDOWNLINT_RC_CONFIG_FILENAMES,
 ];
 
+export { MARKDOWNLINT_IGNORE_FILENAME };
+
 const ALL_CONFIG_FILENAMES = [
 	...ALL_CONFIG_FILENAMES_EXCEPT_PACKAGE_JSON,
 	"package.json",
@@ -50,6 +56,9 @@ function redactConfig(value) {
 		return value.map((item) => redactConfig(item));
 	}
 	if (value && typeof value === "object") {
+		if (typeof value.ignores === "function") {
+			return "<<ignore instance>>";
+		}
 		const redacted = {};
 		for (const [key, entry] of Object.entries(value)) {
 			if (SENSITIVE_KEY_PATTERN.test(key)) {
@@ -207,8 +216,12 @@ export async function loadConfig(
 	});
 
 	const foundConfigs = (await Promise.all(configPromises)).filter(Boolean);
+	const markdownlintIgnoreEntries = await loadMarkdownlintIgnoreEntries(
+		directoriesToSearch,
+		logger,
+	);
 
-	if (foundConfigs.length === 0) {
+	if (foundConfigs.length === 0 && markdownlintIgnoreEntries.length === 0) {
 		logger("No config files found in the file's path.", true);
 		return null;
 	}
@@ -246,18 +259,20 @@ export async function loadConfig(
 		}
 	}
 
-	if (Object.keys(mergedOptions).length > 0) {
-		if (Object.hasOwn(mergedOptions, "ignores")) {
-			delete mergedOptions.ignores;
-		}
-		if (logger) {
-			logger(`Final merged config: ${formatConfigForLog(mergedOptions)}`, true);
-		}
-		if (ignoreEntries.length > 0) {
-			mergedOptions._ignoreEntries = ignoreEntries;
-		}
-		return mergedOptions;
+	if (Object.hasOwn(mergedOptions, "ignores")) {
+		delete mergedOptions.ignores;
 	}
-
-	return null;
+	if (ignoreEntries.length > 0) {
+		mergedOptions._ignoreEntries = ignoreEntries;
+	}
+	if (markdownlintIgnoreEntries.length > 0) {
+		mergedOptions._markdownlintIgnoreEntries = markdownlintIgnoreEntries;
+	}
+	if (Object.keys(mergedOptions).length === 0) {
+		return null;
+	}
+	if (logger) {
+		logger(`Final merged config: ${formatConfigForLog(mergedOptions)}`, true);
+	}
+	return mergedOptions;
 }

--- a/lib/document-validator.mjs
+++ b/lib/document-validator.mjs
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url";
 import { lint } from "markdownlint/promise";
 import { minimatch } from "minimatch";
 import { Diagnostic, DiagnosticSeverity } from "vscode-languageserver/node.js";
+import { isIgnoredByMarkdownlintIgnore } from "./markdownlint-ignore.mjs";
 import mergeOptions from "./merge-options.mjs";
 
 export class DocumentValidator {
@@ -64,20 +65,29 @@ export class DocumentValidator {
 			Array.isArray(mergedOptions._ignoreEntries) &&
 			mergedOptions._ignoreEntries.length > 0
 		) {
-			return mergedOptions._ignoreEntries.some(({ dir, patterns }) => {
-				const relPath = path.relative(dir, filePath);
-				return patterns.some((pattern) =>
-					minimatch(relPath, pattern, { dot: true }),
-				);
-			});
+			const ignoredByConfig = mergedOptions._ignoreEntries.some(
+				({ dir, patterns }) => {
+					const relPath = path.relative(dir, filePath);
+					return patterns.some((pattern) =>
+						minimatch(relPath, pattern, { dot: true }),
+					);
+				},
+			);
+			if (ignoredByConfig) {
+				return true;
+			}
 		}
 
-		return false;
+		return isIgnoredByMarkdownlintIgnore(
+			filePath,
+			mergedOptions._markdownlintIgnoreEntries,
+		);
 	}
 
 	#buildLintOptions(document, mergedOptions) {
 		const {
 			_ignoreEntries: _ignored,
+			_markdownlintIgnoreEntries: _markdownlintIgnored,
 			ignores: _settingsIgnores,
 			...lintOptions
 		} = mergedOptions;

--- a/lib/markdownlint-ignore.mjs
+++ b/lib/markdownlint-ignore.mjs
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import ignore from "ignore";
+
+export const MARKDOWNLINT_IGNORE_FILENAME = ".markdownlintignore";
+
+function toPosixPath(filePath) {
+	return filePath.split(path.sep).join("/");
+}
+
+/**
+ * Loads `.markdownlintignore` files from the given directories.
+ *
+ * @param {string[]} directories Directories to search, ordered from closest to
+ * the file toward the workspace root.
+ * @param {Function} [logger=()=>{}] Optional logger function.
+ * @returns {Promise<Array<{dir: string, ignoreInstance: import("ignore").Ignore}>>}
+ */
+export async function loadMarkdownlintIgnoreEntries(
+	directories,
+	logger = () => {},
+) {
+	const entries = [];
+
+	for (const dir of directories) {
+		const ignorePath = path.join(dir, MARKDOWNLINT_IGNORE_FILENAME);
+		try {
+			const content = await fs.readFile(ignorePath, "utf8");
+			const ignoreInstance = ignore().add(content);
+			logger(`Found ignore file: ${ignorePath}`, true);
+			entries.push({ dir, ignoreInstance });
+		} catch (error) {
+			if (error.code !== "ENOENT" && error.code !== "EISDIR") {
+				logger(`Error reading ${ignorePath}: ${error}`, true);
+			}
+		}
+	}
+
+	return entries;
+}
+
+/**
+ * Returns whether a file path is ignored by any ancestor `.markdownlintignore`
+ * file, using gitignore-style rules relative to each ignore file's directory.
+ *
+ * @param {string} filePath Absolute path to the file being validated.
+ * @param {Array<{dir: string, ignoreInstance: import("ignore").Ignore}>} ignoreEntries
+ * @returns {boolean}
+ */
+export function isIgnoredByMarkdownlintIgnore(filePath, ignoreEntries) {
+	if (!Array.isArray(ignoreEntries) || ignoreEntries.length === 0) {
+		return false;
+	}
+
+	return ignoreEntries.some(({ dir, ignoreInstance }) => {
+		const relativePath = path.relative(dir, filePath);
+		if (
+			!relativePath ||
+			relativePath.startsWith("..") ||
+			path.isAbsolute(relativePath)
+		) {
+			return false;
+		}
+
+		return ignoreInstance.ignores(toPosixPath(relativePath));
+	});
+}

--- a/lib/server.mjs
+++ b/lib/server.mjs
@@ -8,7 +8,10 @@ import {
 	TraceValues,
 } from "vscode-languageserver/node.js";
 import { CodeActions } from "./code-actions.mjs";
-import { ALL_CONFIG_FILENAMES_EXCEPT_PACKAGE_JSON } from "./config.mjs";
+import {
+	ALL_CONFIG_FILENAMES_EXCEPT_PACKAGE_JSON,
+	MARKDOWNLINT_IGNORE_FILENAME,
+} from "./config.mjs";
 import { DocumentRuntime } from "./document-runtime.mjs";
 import { DocumentValidator } from "./document-validator.mjs";
 import mergeOptions from "./merge-options.mjs";
@@ -140,6 +143,9 @@ export class Server {
 							...ALL_CONFIG_FILENAMES_EXCEPT_PACKAGE_JSON.map((pattern) => ({
 								globPattern: `**/${pattern}`,
 							})),
+							{
+								globPattern: `**/${MARKDOWNLINT_IGNORE_FILENAME}`,
+							},
 							{
 								globPattern: "**/package.json",
 							},

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	},
 	"homepage": "https://github.com/vitallium/markdownlint-lsp#readme",
 	"dependencies": {
+		"ignore": "^7.0.5",
 		"js-yaml": "^5.2.1",
 		"markdownlint": "^0.41.0",
 		"minimatch": "^10.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ignore:
+        specifier: ^7.0.5
+        version: 7.0.5
       js-yaml:
         specifier: ^5.2.1
         version: 5.2.1
@@ -283,6 +286,10 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -776,6 +783,8 @@ snapshots:
   has-flag@4.0.0: {}
 
   he@1.2.0: {}
+
+  ignore@7.0.5: {}
 
   is-alphabetical@2.0.1: {}
 

--- a/test/configuration.test.mjs
+++ b/test/configuration.test.mjs
@@ -487,6 +487,75 @@ no-duplicate-heading:
 		});
 	});
 
+	describe(".markdownlintignore", () => {
+		it("should suppress diagnostics for files listed in .markdownlintignore", async () => {
+			const testDir = await prepareTestDir("markdownlintignore");
+			const subDir = path.join(testDir, "generated");
+			await fs.mkdir(subDir, { recursive: true });
+
+			await fs.writeFile(
+				path.join(testDir, ".markdownlintignore"),
+				"generated/\nCHANGELOG.md\n",
+			);
+
+			const ignoredInDirUri = `file://${path.join(subDir, "notes.md")}`;
+			const ignoredFileUri = `file://${path.join(testDir, "CHANGELOG.md")}`;
+			const lintedUri = `file://${path.join(testDir, "README.md")}`;
+			const badContent =
+				"# Hello\n## Bad heading increment skipped\n### skip\n";
+
+			await client.openTextDocument(ignoredInDirUri, badContent);
+			expect(
+				await client.waitForDiagnosticsArray(ignoredInDirUri),
+			).to.have.length(0);
+
+			await client.openTextDocument(ignoredFileUri, badContent);
+			expect(
+				await client.waitForDiagnosticsArray(ignoredFileUri),
+			).to.have.length(0);
+
+			await client.openTextDocument(lintedUri, badContent);
+			expect(
+				await client.waitForDiagnosticsArray(lintedUri),
+			).to.have.length.greaterThan(0);
+		});
+
+		it("should apply nested .markdownlintignore files", async () => {
+			const baseDir = await prepareTestDir("markdownlintignore-nested");
+			const nestedDir = path.join(baseDir, "docs");
+			await fs.mkdir(nestedDir, { recursive: true });
+
+			await fs.writeFile(
+				path.join(baseDir, ".markdownlintignore"),
+				"docs/legacy/**\n",
+			);
+			await fs.writeFile(
+				path.join(nestedDir, ".markdownlintignore"),
+				"drafts/**\n",
+			);
+
+			const legacyUri = `file://${path.join(nestedDir, "legacy", "old.md")}`;
+			const draftUri = `file://${path.join(nestedDir, "drafts", "wip.md")}`;
+			const lintedUri = `file://${path.join(nestedDir, "published.md")}`;
+			const badContent =
+				"# Hello\n## Bad heading increment skipped\n### skip\n";
+
+			await fs.mkdir(path.join(nestedDir, "legacy"), { recursive: true });
+			await fs.mkdir(path.join(nestedDir, "drafts"), { recursive: true });
+
+			await client.openTextDocument(legacyUri, badContent);
+			expect(await client.waitForDiagnosticsArray(legacyUri)).to.have.length(0);
+
+			await client.openTextDocument(draftUri, badContent);
+			expect(await client.waitForDiagnosticsArray(draftUri)).to.have.length(0);
+
+			await client.openTextDocument(lintedUri, badContent);
+			expect(
+				await client.waitForDiagnosticsArray(lintedUri),
+			).to.have.length.greaterThan(0);
+		});
+	});
+
 	describe("RC-style Configuration", () => {
 		it("should load .markdownlintrc configuration", async () => {
 			const testDir = await prepareTestDir("rc");

--- a/test/markdownlint-ignore.test.mjs
+++ b/test/markdownlint-ignore.test.mjs
@@ -1,0 +1,61 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect } from "chai";
+import ignore from "ignore";
+import { after, before, describe, it } from "mocha";
+import {
+	isIgnoredByMarkdownlintIgnore,
+	loadMarkdownlintIgnoreEntries,
+} from "../lib/markdownlint-ignore.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe("markdownlint-ignore", () => {
+	const baseDir = path.join(__dirname, "fixtures", "temp-markdownlintignore");
+
+	before(async () => {
+		await fs.rm(baseDir, { recursive: true, force: true });
+		await fs.mkdir(path.join(baseDir, "nested"), { recursive: true });
+		await fs.writeFile(path.join(baseDir, ".markdownlintignore"), "root.md\n");
+		await fs.writeFile(
+			path.join(baseDir, "nested", ".markdownlintignore"),
+			"nested.md\n",
+		);
+	});
+
+	after(async () => {
+		await fs.rm(baseDir, { recursive: true, force: true });
+	});
+
+	it("should match gitignore-style patterns relative to the ignore file", () => {
+		const ignoreEntries = [
+			{
+				dir: baseDir,
+				ignoreInstance: ignore().add("generated/\nCHANGELOG.md\n"),
+			},
+		];
+
+		expect(
+			isIgnoredByMarkdownlintIgnore(
+				path.join(baseDir, "generated", "notes.md"),
+				ignoreEntries,
+			),
+		).to.equal(true);
+		expect(
+			isIgnoredByMarkdownlintIgnore(
+				path.join(baseDir, "README.md"),
+				ignoreEntries,
+			),
+		).to.equal(false);
+	});
+
+	it("should load ignore entries from directories on the search path", async () => {
+		const nestedDir = path.join(baseDir, "nested");
+		const entries = await loadMarkdownlintIgnoreEntries([nestedDir, baseDir]);
+		expect(entries).to.have.length(2);
+		expect(entries[0].dir).to.equal(nestedDir);
+		expect(entries[1].dir).to.equal(baseDir);
+	});
+});


### PR DESCRIPTION
Load gitignore-style patterns from .markdownlintignore files along the document path, skip linting for matching files, and watch ignore files for changes.